### PR TITLE
Add Emcognito (forward-metered alias service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Think of it like a P.O. Box for your email - you hand out forwarding addresses, 
 | [Forward Email](https://forwardemail.net) | USA 🇺🇸 | ✅ (own domain) | $3/mo | Paid only | ✅ | AES-256 at rest, 10GB storage |
 | [DuckDuckGo Email](https://duckduckgo.com/email) | USA 🇺🇸 | ✅ (unlimited) | Free only | ✅ | Partial | Tracker removal |
 | [Firefox Relay](https://relay.firefox.com) | USA 🇺🇸 | ✅ (50 masks) | $0.99/mo | Premium | Partial | Phone masking on Premium |
+| [Emcognito](https://emcognito.com) | USA 🇺🇸 | ✅ (unlimited aliases, 100 forwards/mo) | $2/mo | ✅ | ❌ | Meters forwards, not aliases; passwordless |
 | [AdGuard Mail](https://adguard.com/adguard-temp-mail) | Cyprus 🇨🇾 | ✅ (limited) | $2.99/mo | Premium | Partial | Temporary aliases |
 | [33Mail](https://33mail.com) | UK 🇬🇧 | ✅ | $1/mo | Premium | ❌ | Simple, long-standing service |
 | [Ivy by IronVest](https://getivy.ai) | USA 🇺🇸 | ❌ | $3.25/mo ($39/yr) | ✅ | ❌ | AI copilot, email + phone + card masking |
@@ -168,6 +169,7 @@ Think of it like a P.O. Box for your email - you hand out forwarding addresses, 
 | SimpleLogin | 10 (+ Proton Pass Free) | ✅ | ❌ | PGP, mobile apps, browser extensions, Proton Pass Free included | Beginners |
 | DuckDuckGo | Unlimited `@duck.com` | ✅ | ❌ | Tracker removal, browser autofill | Quickest start |
 | Firefox Relay | 50 masks | ❌ | ❌ | Tracker removal, Firefox integration | Mozilla users |
+| Emcognito | Unlimited (100 forwards/mo) | ✅ | ❌ | Passwordless (magic link/passkey), suspend/resume per alias, no body storage | Unlimited aliases with reply on free |
 | AdGuard Mail | ~10 | ❌ | ❌ | Temporary alias option | Light/casual use |
 | 33Mail | Unlimited | ❌ | ❌ | Simple and reliable | Basic forwarding |
 | Erine.email | Unlimited | ✅ | ❌ | Open-source, EU-hosted | Privacy advocates |
@@ -191,6 +193,8 @@ Think of it like a P.O. Box for your email - you hand out forwarding addresses, 
 | **Forward Email Enhanced** | $3/mo | Unlimited | ✅ | Unlimited | AES-256 at rest, 10GB IMAP, webhooks, API |
 | **Forward Email Team** | $9/mo | Unlimited | ✅ | Unlimited | Shared team access, priority support |
 | **Firefox Relay Premium** | $0.99/mo | Unlimited masks | ✅ | 1 subdomain | Phone masking (US/CA), tracker removal |
+| **Emcognito Plus** | $2/mo ($20/yr) | Unlimited | ✅ | ❌ | 2,500 forwards/mo, compose new mail from an alias, no footer on forwards |
+| **Emcognito Pro** | $4/mo ($36/yr) | Unlimited | ✅ | ❌ | 15,000 forwards/mo, higher daily compose limit |
 | **AdGuard Mail Premium** | $2.99/mo | ~1,000 | ✅ | 1 | Anonymous replies, premium domains |
 | **33Mail Premium** | $1/mo | Unlimited | ✅ (20/day) | 1 | Simple, long-standing |
 | **33Mail Pro** | $5/mo | Unlimited | ✅ (100/day) | 5 | Higher volume |
@@ -201,6 +205,7 @@ Think of it like a P.O. Box for your email - you hand out forwarding addresses, 
 
 > [!NOTE]
 > - "Unlimited" means no fixed hard cap but subject to fair-use/abuse limits.
+> - Emcognito meters **forwarded messages per month** rather than the number of aliases. Every tier including free allows unlimited aliases; the plan price buys forwarding volume. Note this is a different trade rather than a strictly better one — DuckDuckGo and 33Mail give unlimited free aliases with no forward cap.
 > - SimpleLogin Premium now **includes Proton Pass Plus** at no extra cost (as of Nov 2024).
 > - Firefox Relay phone masking is available in the US and Canada only.
 > - Regional pricing varies; always verify on the provider's official site.
@@ -278,6 +283,7 @@ Think of it like a P.O. Box for your email - you hand out forwarding addresses, 
 | Forward Email | Queue/delivery only; self-host option | Configurable / self-host | None by default | Minimal: domain configs + DNS only |
 | DuckDuckGo Email | Strips trackers; minimal logs | Minimization approach | Anonymous/aggregate | Email address only stored |
 | Firefox Relay | Delivery only; deleted after forward | Mozilla policies | Mozilla telemetry (opt-out) | Mozilla account data |
+| Emcognito | Not stored — deleted once SES accepts; no message-body field exists | AWS request metadata (IP, UA, timestamp) | Google Analytics 4, incl. signed-in app | Over-cap mail held 72h, then deleted |
 | AdGuard Mail | Delivery only | Anti-abuse logs | Internal | Email and account data |
 | 33Mail | Delivery only | Standard logs | Unknown | Basic account info |
 | Ivy (IronVest) | Delivery only; zero-knowledge architecture | Standard logs | Basic | Account and payment data |
@@ -298,6 +304,7 @@ Think of it like a P.O. Box for your email - you hand out forwarding addresses, 
 |---|---|---|---|---|
 | SimpleLogin | All existing aliases (receive + reply within free limits) | New alias creation beyond 10 | Nothing permanent | **Minimal** - aliases stay active forever |
 | Forward Email | Existing forwarding | Premium SMTP/API, priority support | Some premium configs | **Low** |
+| Emcognito | All aliases keep receiving | Forwards above 100/mo | Nothing permanent | **Moderate** — over-cap mail is held 72h, then lost |
 | AdGuard Mail | Free features and base quota | Premium domains/features | Premium-only aliases | **Low** |
 | 33Mail | Basic forwarding | Custom domains, higher reply limits | Custom domain configs | **Moderate** |
 | Firefox Relay | First 50 masks | Extra masks | Masks beyond free limit | **Moderate** |
@@ -320,6 +327,7 @@ Think of it like a P.O. Box for your email - you hand out forwarding addresses, 
 | Addy.io | Netherlands 🇳🇱 (EU) | ✅ | EU legal process required |
 | StartMail | Netherlands 🇳🇱 (EU) | ✅ | EU legal process required |
 | Erine.email | France 🇫🇷 (EU) | ✅ | EU legal process required |
+| Emcognito | United States 🇺🇸 | ✅ (applicable) | US law |
 | AdGuard Mail | Cyprus 🇨🇾 (EU) | ✅ | EU legal process required |
 | 33Mail | United Kingdom 🇬🇧 | ✅ (UK GDPR) | UK legal process |
 | Forward Email | United States 🇺🇸 | ✅ (applicable) | US law; self-host option available |


### PR DESCRIPTION
Adds **Emcognito** ([emcognito.com](https://emcognito.com)) to the comparison tables.

**Disclosure: I'm associated with Emcognito.** Everything below is source-linked and dated so you can check it rather than take my word for it.

*Updated 2026-07-29 — rebased onto current `main` to clear the conflict, and **two claims from my original submission corrected**. Detail at the bottom; I'd rather flag them than have you find them.*

### Why it's a distinct entry

Emcognito meters **forwarded messages per month** rather than capping the number of aliases. Every tier including free allows unlimited aliases; the plan price buys forwarding volume — the inverse of most providers here.

I've written that up in the Paid Plans note as a *different* trade rather than a better one, because it isn't strictly better: **DuckDuckGo and 33Mail both give unlimited free aliases with no forward cap at all.** On raw free volume they beat us.

Where it is genuinely distinct is the free tier combination — unlimited aliases **with reply support** and no setup. Per your Free Plans table, Addy.io and 33Mail are ❌ on free reply, and Forward Email needs your own domain. That leaves DuckDuckGo as the close comparator.

### Data added (verified 2026-07-29)

| | |
|---|---|
| Jurisdiction | USA 🇺🇸 (AWS us-east-1) |
| Free | Unlimited aliases, 100 forwards/mo, reply support, passwordless (magic link / passkey) |
| Plus | $2/mo ($20/yr) — 2,500 forwards/mo, compose new mail from an alias |
| Pro | $4/mo ($36/yr) — 15,000 forwards/mo |
| Custom domains | ❌ not available on any tier |
| Reply support | ✅ all tiers including free |
| Open source | ❌ |

### Now covers all six tables

The original only touched three. This adds Data Collection and Retention, Cancellation / Downgrade Behavior, and Legal and Compliance, so it meets CONTRIBUTING.md's requirements for a new provider.

Those include the unflattering details:

- **Analytics: Google Analytics 4, including the signed-in app.** Weaker than Addy.io's self-hosted or SimpleLogin's Plausible. It's in the table because it's true.
- **Cancellation risk: Moderate.** Aliases keep receiving, but mail above 100/mo is held **72 hours** and then deleted.

### Corrections to my original submission

Two claims were wrong and are removed:

1. **`$0.001/send overage` on Pro** — there is no metered price and nothing bills for it. The opt-in flag is read but never written, and there's no usage-record path in the service. It was wrong when I submitted it, not merely outdated.
2. **`1 subdomain (coming Q3)`** — custom domains still aren't shipped. A roadmap item doesn't belong in a comparison table; the Domains column now reads ❌.

I found these auditing our own marketing claims, and it seemed worse to leave them sitting in an open PR to a comparison you maintain for accuracy.

### Sources

- Pricing: <https://emcognito.com/pricing>
- Privacy policy (body storage, IP, analytics, 72h hold): <https://emcognito.com/privacy-policy>

Neutral tone, no affiliate or promotional links, per CONTRIBUTING.md. I've deliberately **not** added Emcognito to the Provider Selector — that's your editorial recommendation to make, not mine. Happy to adjust placement or wording, and equally happy to fact-check any competitor row while I'm here.